### PR TITLE
Add FastScrolling to RecyclerView in ColorActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0-alpha03'
     implementation 'androidx.preference:preference:1.1.0-alpha03'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha3'
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.airbnb.android:lottie:3.0.0'
     implementation 'com.github.duanhong169:colorpicker:1.1.6'
 }

--- a/app/src/main/res/drawable/line.xml
+++ b/app/src/main/res/drawable/line.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/transparent" />
+</shape>

--- a/app/src/main/res/drawable/line_drawable.xml
+++ b/app/src/main/res/drawable/line_drawable.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/line" android:state_pressed="true" />
+    <item android:drawable="@drawable/line" />
+</selector>

--- a/app/src/main/res/drawable/thumb.xml
+++ b/app/src/main/res/drawable/thumb.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#4DFFFFFF" />
+</shape>

--- a/app/src/main/res/drawable/thumb_drawable.xml
+++ b/app/src/main/res/drawable/thumb_drawable.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/thumb" android:state_pressed="true" />
+    <item android:drawable="@drawable/thumb" />
+</selector>

--- a/app/src/main/res/layout/activity_color.xml
+++ b/app/src/main/res/layout/activity_color.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,7 +11,11 @@
         android:id="@+id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:scrollbars="vertical"
+        app:fastScrollEnabled="true"
+        app:fastScrollHorizontalThumbDrawable="@drawable/thumb_drawable"
+        app:fastScrollHorizontalTrackDrawable="@drawable/line_drawable"
+        app:fastScrollVerticalThumbDrawable="@drawable/thumb_drawable"
+        app:fastScrollVerticalTrackDrawable="@drawable/line_drawable"
         tools:listitem="@layout/item_color" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Some apps may create huge number of channels (e.g. Telegram creates a channel for every new chat), causing the list to be difficult to scroll. This commit adds fast scrolling to the recyclerview to enable users to quickly scroll through the list.